### PR TITLE
Fix bugs

### DIFF
--- a/BaseAspect.aj
+++ b/BaseAspect.aj
@@ -1,0 +1,23 @@
+public aspect BaseAspect {
+  pointcut notwithin() :
+  !within(sun..*) &&
+  !within(java..*) &&
+  !within(javax..*) &&
+  !within(javafx..*) &&
+  !within(com.sun..*) &&
+  !within(org.dacapo.harness..*) &&
+  !within(net.sf.cglib..*) &&
+  !within(mop..*) &&
+  !within(javamoprt..*) &&
+  !within(rvmonitorrt..*) &&
+  !within(org.junit..*) &&
+  !within(junit..*) &&
+  !within(java.lang.Object) &&
+  !within(com.runtimeverification..*) &&
+  !within(org.apache.maven.surefire..*) &&
+  !within(org.mockito..*) &&
+  !within(org.powermock..*) &&
+  !within(org.easymock..*) &&
+  !within(com.mockrunner..*) &&
+  !within(org.jmock..*);
+}

--- a/generate-agent.sh
+++ b/generate-agent.sh
@@ -23,17 +23,18 @@ eval "mkdir -p $TEMP_DIR/mop"
 
 RVM_FILES="${MOP_FILES//mop/rvm}"
 
-eval "javamop -merge '$MOP_FILES' -d $TEMP_DIR/"
-eval "rv-monitor -merge -d $TEMP_DIR/mop/ $RVM_FILES"
+eval "javamop -merge '$MOP_FILES'"
+mv ${MOP_FILES}/MultiSpec_1MonitorAspect.aj $TEMP_DIR
+eval "rv-monitor -merge -d $TEMP_DIR/mop/ $MOP_FILES/*.rvm"
 eval "javac $TEMP_DIR/mop/MultiSpec_1RuntimeMonitor.java"
 
 if [ $EXCLUDE = 'n' ]; then
-	$EXCLUDE_OPT='' # jars will not be excluded
+	EXCLUDE_OPT='' # jars will not be excluded
 else
-	$EXCLUDE_OPT='-excludeJars'
+	EXCLUDE_OPT='-excludeJars'
 fi
 
-eval "javamopagent $TEMP_DIR/MultiSpec_1MonitorAspect.aj $TEMP_DIR -n $OUTPUT_NAME $EXCLUDE_OPT"
+eval "javamopagent -m $TEMP_DIR/MultiSpec_1MonitorAspect.aj $TEMP_DIR/ -n $OUTPUT_NAME $EXCLUDE_OPT"
 eval "rm -r $TEMP_DIR"
 
 

--- a/generate-agent.sh
+++ b/generate-agent.sh
@@ -23,7 +23,7 @@ eval "mkdir -p $TEMP_DIR/mop"
 
 RVM_FILES="${MOP_FILES//mop/rvm}"
 
-eval "javamop -merge '$MOP_FILES'"
+eval "javamop -baseaspect BaseAspect.aj -merge '$MOP_FILES'"
 mv ${MOP_FILES}/MultiSpec_1MonitorAspect.aj $TEMP_DIR
 eval "rv-monitor -merge -d $TEMP_DIR/mop/ $MOP_FILES/*.rvm"
 eval "javac $TEMP_DIR/mop/MultiSpec_1RuntimeMonitor.java"
@@ -34,7 +34,5 @@ else
 	EXCLUDE_OPT='-excludeJars'
 fi
 
-eval "javamopagent -m $TEMP_DIR/MultiSpec_1MonitorAspect.aj $TEMP_DIR/ -n $OUTPUT_NAME $EXCLUDE_OPT"
+eval "javamopagent $TEMP_DIR/MultiSpec_1MonitorAspect.aj $TEMP_DIR/ -n $OUTPUT_NAME $EXCLUDE_OPT"
 eval "rm -r $TEMP_DIR"
-
-


### PR DESCRIPTION
1. `javamop` does not require the `-d` when building agent. See the [doc](https://github.com/runtimeverification/javamop/blob/master/docs/JavaMOPAgentUsage.md)

2. It seems that the generation of a default `BaseAspect.aj` is broken, so you need to pass one in

3. `javamop` generates `MultiSpec_1MonitorAspect.aj` in the same directory as the `*.mop` files, you need to somehow take that into account by copying it over as I have, or simply use `${MOP_FILES}` directory as your ${TEMP_DIR}